### PR TITLE
Add new style for compound identifiers in Progress ABL

### DIFF
--- a/lexers/LexProgress.cxx
+++ b/lexers/LexProgress.cxx
@@ -341,7 +341,14 @@ void SCI_METHOD LexerABL::Lex(Sci_PositionU startPos, Sci_Position length, int i
                char s[1000];
                sc.GetCurrentLowered(s, sizeof(s));
                bool isLastWordEnd = (s[0] == 'e' && s[1] =='n' && s[2] == 'd' && !IsAlphaNumeric(s[3]) && s[3] != '-');  // helps to identify "end trigger" phrase
-               if ((isSentenceStart && keywords2.InListAbbreviated (s,'(')) || (!isLastWordEnd && keywords3.InListAbbreviated (s,'('))) {
+               if (sc.ch == '.' && setWord.Contains(sc.chNext)) {
+                   // identifier.identifer[.identifier ...] - stay in the identifier state until not id char and not .
+                   // - is not included in the test above because it's not valid as the start of an identifier
+                   sc.Forward();
+                   sc.SetState(SCE_ABL_IDENTIFIER2);
+                   break;
+               }
+               else if ((isSentenceStart && keywords2.InListAbbreviated (s,'(')) || (!isLastWordEnd && keywords3.InListAbbreviated (s,'('))) {
                   sc.ChangeState(SCE_ABL_BLOCK);
                   isSentenceStart = false;
                }
@@ -364,6 +371,15 @@ void SCI_METHOD LexerABL::Lex(Sci_PositionU startPos, Sci_Position length, int i
                sc.SetState(SCE_ABL_DEFAULT);
             }
             break;
+         case SCE_ABL_IDENTIFIER2:
+             // identifier.identifer[.identifier ...] - exit this state when we find something
+             // that's not a valid character in an identifier
+             // .* is included for cases like: USING System.Collections.*
+             if (sc.ch != '.' && sc.ch != '-' && !(sc.ch == '*' && sc.chPrev == '.') && !setWord.Contains(sc.ch)) {
+                 sc.SetState(SCE_ABL_DEFAULT);
+                 isSentenceStart = false;
+             }
+             break;
          case SCE_ABL_PREPROCESSOR:
             if (sc.atLineStart && !continuationLine) {
                sc.SetState(SCE_ABL_DEFAULT);


### PR DESCRIPTION
Add new style for compound identifiers in Progress ABL. Compound identifiers are of the form "identifier.identifier[.identifier ...]" and should be styled as a single unit.